### PR TITLE
Proxy native requests with a separate object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ node_js:
   - '6'
   - '5'
   - '4'
-  - '0.12'
-  - '0.10'
 
 after_script:
   - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/test/test-with-server.js
+++ b/test/test-with-server.js
@@ -187,6 +187,58 @@ describe('follow-redirects ', function () {
 		}
 	});
 
+	it('should provide flushHeaders', function (done) {
+		app.get('/a', redirectsTo('/b'));
+		app.get('/b', sendsJson({foo: 'bar'}));
+
+		server.start(app)
+			.then(asPromise(function (resolve, reject) {
+				var request = http.get('http://localhost:3600/a', resolve);
+				request.flushHeaders();
+				request.on('response', resolve);
+				request.on('error', reject);
+			}))
+			.nodeify(done);
+	});
+
+	it('should provide setNoDelay', function (done) {
+		app.get('/a', redirectsTo('/b'));
+		app.get('/b', sendsJson({foo: 'bar'}));
+
+		server.start(app)
+			.then(asPromise(function (resolve, reject) {
+				var request = http.get('http://localhost:3600/a', resolve);
+				request.setNoDelay(true);
+				request.on('response', resolve);
+				request.on('error', reject);
+			}))
+			.nodeify(done);
+	});
+
+	it('should provide setSocketKeepAlive', function (done) {
+		app.get('/a', redirectsTo('/b'));
+		app.get('/b', sendsJson({foo: 'bar'}));
+
+		server.start(app)
+			.then(asPromise(function (resolve) {
+				var request = http.get('http://localhost:3600/a', resolve);
+				request.setSocketKeepAlive(true);
+			}))
+			.nodeify(done);
+	});
+
+	it('should provide setTimeout', function (done) {
+		app.get('/a', redirectsTo('/b'));
+		app.get('/b', sendsJson({foo: 'bar'}));
+
+		server.start(app)
+			.then(asPromise(function (resolve) {
+				var request = http.get('http://localhost:3600/a', resolve);
+				request.setTimeout(1000);
+			}))
+			.nodeify(done);
+	});
+
 	describe('should obey a `maxRedirects` property ', function () {
 		it('which defaults to 5', function (done) {
 			app.get('/a', redirectsTo('/b'));


### PR DESCRIPTION
The technique used in b4554ff196815141bd51291fabda2b23026c8e48 to proxy a request seems to introduce a problem in which connections are not properly closed.

This pull requests adds a separate object to act as a proxy of native requests, which as an added benefit brings #34.