### PR TITLE
Pass on 'socket'-event

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var safeMethods = {GET: true, HEAD: true, OPTIONS: true, TRACE: true};
 
 // Create handlers that pass events from native requests
 var eventHandlers = Object.create(null);
-['abort', 'aborted', 'error'].forEach(function (event) {
+['abort', 'aborted', 'error', 'socket'].forEach(function (event) {
 	eventHandlers[event] = function (arg) {
 		this._redirectable.emit(event, arg);
 	};

--- a/test/test-with-server.js
+++ b/test/test-with-server.js
@@ -1,6 +1,7 @@
 describe('follow-redirects ', function () {
 	var express = require('express');
 	var assert = require('assert');
+	var net = require('net');
 	var server = require('./lib/test-server')({
 		https: 3601,
 		http: 3600
@@ -113,6 +114,21 @@ describe('follow-redirects ', function () {
 			}))
 			.then(function (error) {
 				assert.equal(error.code, 'ECONNREFUSED');
+			})
+			.nodeify(done);
+	});
+
+	it('should emit socket events on the returned stream', function (done) {
+		app.get('/a', sendsJson({a: 'b'}));
+
+		server.start(app)
+			.then(asPromise(function (resolve, reject) {
+				http.get('http://localhost:3600/a')
+						.on('socket', resolve)
+						.on('error', reject);
+			}))
+			.then(function (socket) {
+				assert(socket instanceof net.Socket, 'socket event should emit with socket');
 			})
 			.nodeify(done);
 	});


### PR DESCRIPTION
This PR makes sure the 'socket' event is passed on to the returned stream. This makes modules like [timed-out](https://github.com/floatdrop/timed-out) work with `follow-redirects`.