### PR TITLE
proposal for fixing issue 53: 'Exceeding Max Redirects when using a p…

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,12 @@ RedirectableRequest.prototype._processResponse = function (response) {
 		var redirectUrl = url.resolve(this._currentUrl, location);
 		debug('redirecting to', redirectUrl);
 		Object.assign(this._options, url.parse(redirectUrl));
+		// Fix: 'this._options.headers.Host' may be inconsistent with the new value of 'this._options.host', which may
+		// be the cause of unlimited redirections. The following line manually fixes such an inconsistency and addresses
+		// issue #53.
+		if (Object.prototype.hasOwnProperty.call(this._options, 'headers') && (this._options.headers.Host !== this._options.host)) {
+			this._options.headers.Host = this._options.host;
+		}
 		this._currentResponse = response;
 		this._performRequest();
 	} else {

--- a/index.js
+++ b/index.js
@@ -133,10 +133,10 @@ RedirectableRequest.prototype._processResponse = function (response) {
 		debug('redirecting to', redirectUrl);
 		Object.assign(this._options, url.parse(redirectUrl));
 		// Fix: 'this._options.headers.Host' may be inconsistent with the new value of 'this._options.host', which may
-		// be the cause of unlimited redirections. The following line manually fixes such an inconsistency and addresses
-		// issue #53.
-		if (Object.prototype.hasOwnProperty.call(this._options, 'headers') && (this._options.headers.Host !== this._options.host)) {
-			this._options.headers.Host = this._options.host;
+		// be the cause of unlimited redirections (issue 53). The following line remove the outdated
+		// 'this._options.headers.Host' property.
+		if (Object.prototype.hasOwnProperty.call(this._options, 'headers') && Object.prototype.hasOwnProperty.call(this._options.headers, 'Host')) {
+			delete this._options.headers.Host;
 		}
 		this._currentResponse = response;
 		this._performRequest();

--- a/test/test-with-server.js
+++ b/test/test-with-server.js
@@ -591,6 +591,37 @@ describe('follow-redirects ', function () {
 		});
 	});
 
+	describe('should handle redirection to a different domain', function () {
+		it('even if "headers.Host" has been set (testing with google.com)', function (done) {
+			function callback(resolve, reject) {
+				return function (res) {
+					res.pipe(concat({encoding: 'string'}, function () {
+						try {
+							resolve(res);
+						} catch (err) {
+							reject(new Error('error resolving ' + res + '\n caused by: ' + err.message));
+						}
+					})).on('error', reject);
+				};
+			}
+
+			BPromise.all([])
+				.then(asPromise(function (resolve, reject) {
+					var opts = {
+						headers: {
+							Host: 'google.com'
+						},
+						host: 'google.com'
+					};
+					http.get(opts, callback(resolve, reject)).on('error', reject);
+				}))
+				.then(function (res) {
+					assert(res.responseUrl.includes('www.google'));
+				})
+				.nodeify(done);
+		});
+	});
+
 	describe('should choose the right agent per protocol', function () {
 		it('(https -> http -> https)', function (done) {
 			app.get('/a', redirectsTo('http://localhost:3600/b'));


### PR DESCRIPTION
Hello,

this pull request contains a proposal for fixing [issue #53](https://github.com/olalonde/follow-redirects/issues/53).

When requesting "google.com", the response was suggesting to request "www.google.com". While [line 134 of index.js](https://github.com/olalonde/follow-redirects/blob/master/index.js#L134) was updating **_options** with values targeting the suggested url ("www.google.com"), **_options.header.Host** could still contain the previous host ("google.com"), causing an infinite redirection.

The fix proposes to manually ensure that **_options.header.Host** has the new host value.

All the tests are OK, and you can test the fix with the following javascript code:
```javascript
var followRedirect = require('follow-redirects');
var http = followRedirect.http;
var urllib = require('url');

var proxy = "http://137.74.254.198:3128/"; // public proxy
var target = "http://google.com";
if (process.argv.length == 3) {
	proxy = process.argv[2];
} else if (process.argv.length == 4) {
	proxy = process.argv[2];
	target = process.argv[3];
}

var options = urllib.parse(proxy);
var targetOpt = urllib.parse(target);

options.headers = {
	"Host": targetOpt.host
}

options.pathname = target;
options.path = target;

console.log(options);

var req = http.request(options,function(res){
	var body = "";
	res.on('data',function(chunk){
		body += chunk;
	});

	res.on('end',function(){
		console.log("All Donei %d", res.statusCode);
		console.log(body);
	});
});

req.setTimeout(120000, function(){
	console.log("timeout");
	req.abort();
});

req.on('error', function(err){
	console.log(err);
});

req.end();
```

Best regards,

Jonathan Pastor