### PR TITLE
Fix hanging application when the final response is destroyed prematurely

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,6 +220,10 @@ RedirectableRequest.prototype._processResponse = function (response) {
     Object.assign(this._options, url.parse(redirectUrl));
     this._isRedirect = true;
     this._performRequest();
+
+    // Void the remaining response
+    // This also avoid memory leaks and hanging applications if the final response is destroyed prematurely
+    response.destroy();
   }
   else {
     // The response is not a redirect; return it as-is


### PR DESCRIPTION
This calls `destroy()` on the redirected responses
as soon as they are not needed anymore.

This fixes the case where the application would hang if `destroy()`
would be called on the final response without it being consumed
completely.

This also slightly improves performance,
as the redirected responses can be cleaned up immediately.