### PR TITLE
Remove bluebird

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
 
   env: {
     node: true,
+    es6: true
   },
 
   rules: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -190,12 +190,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-      "dev": true
-    },
     "body-parser": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "debug": "=3.1.0"
   },
   "devDependencies": {
-    "bluebird": "^3.5.1",
     "concat-stream": "^1.6.0",
     "coveralls": "^3.0.0",
     "eslint": "^4.19.1",

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -1,5 +1,4 @@
 var concat = require("concat-stream");
-var BPromise = require("bluebird");
 
 function redirectsTo() {
   var args = Array.prototype.slice.call(arguments);
@@ -30,7 +29,7 @@ function concatJson(resolve, reject) {
 
 function asPromise(cb) {
   return function (result) {
-    return new BPromise(function (resolve, reject) {
+    return new Promise(function (resolve, reject) {
       cb(resolve, reject, result);
     });
   };


### PR DESCRIPTION
We're able to easily remove bluebird (development dependency) since Node.js v4 natively supports promises.

Mocha supports returning promises to signal test completion instead of using `done` callbacks.